### PR TITLE
docker-compose pullとdocker-compose upのオプションを修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,12 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+  - echo "$REGISTRY_PASSWORD" | docker login -u "$REGISTRY_USER" --password-stdin
 install:
-  - docker-compose pull
+  - docker-compose pull scala-text-pdf-compile
   - docker-compose build
 script:
-  - docker-compose up --exit-code-from scala-text-pdf-compile
+  - docker-compose up --abort-on-container-exit
 before_cache:
   - find $HOME/.sbt -name "*.lock" | sudo xargs rm
   - find $HOME/.ivy2 -name "ivydata-*.properties" | sudo xargs rm

--- a/travis/deploy_image.sh
+++ b/travis/deploy_image.sh
@@ -3,7 +3,6 @@
 set -ex
 
 if [[ "${TRAVIS_OS_NAME}" == "linux" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then
-  echo "$REGISTRY_PASSWORD" | docker login -u "$REGISTRY_USER" --password-stdin
   docker tag "$IMAGE_NAME" "${IMAGE_NAME}:latest"
   docker push "${IMAGE_NAME}:latest"
 fi


### PR DESCRIPTION
- `docker-compose pull`で正しくイメージがダウンロードされてなかったのでオプションを追加
- `using --exit-code-from implies --abort-on-container-exit`という警告がでていたので`docker-compose up`のオプションを変更