### PR TITLE
PandocやLaTeXで使用するフォントなどを更新

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM pandoc/core:2.9.1
+FROM pandoc/core:2.11
 
 MAINTAINER yyu <yyu [at] mental.poker>
 
@@ -23,8 +23,7 @@ ENV FONT_PATH /usr/share/fonts/
 
 ENV PERSISTENT_DEPS \
     openjdk8 \
-    python \
-    py2-pip \
+    py-pip \
     wget \
     make \
     perl \
@@ -46,6 +45,7 @@ RUN apk add --no-cache --virtual .persistent-deps $PERSISTENT_DEPS
 # Setup fonts
 RUN mkdir -p $FONT_PATH && \
     apk add --no-cache --virtual .font-deps $FONT_DEPS && \
+    # Source Code Pro
     wget https://github.com/adobe-fonts/source-code-pro/archive/2.030R-ro/1.050R-it.zip && \
       unzip 1.050R-it.zip && \
       cp source-code-pro-2.030R-ro-1.050R-it/OTF/*.otf $FONT_PATH && \
@@ -74,7 +74,9 @@ RUN apk add --no-cache --virtual .texlive-deps $TEXLIVE_DEPS && \
       -profile /tmp/install-tl-unx/texlive.profile && \
     tlmgr install latexmk collection-luatex collection-langjapanese \
       collection-fontsrecommended filehook type1cm mdframed needspace \
-      fncychap everyhook svn-prov letltxmacro zref && \
+      fncychap everyhook svn-prov letltxmacro zref sourcesanspro \
+      cm-unicode sourceserifpro haranoaji && \
+    luaotfload-tool -u -vvv && \
     rm -fr /tmp/install-tl-unx && \
     apk del .texlive-deps
 
@@ -82,4 +84,4 @@ VOLUME ["/workdir", "/root/.sbt", "/root/.ivy2"]
 
 WORKDIR /workdir
 
-ENTRYPOINT ["/bin/bash", "-c", "./setup.sh && USE_IPAFONT=true make"]
+ENTRYPOINT ["/bin/bash", "-c", "./setup.sh && make"]

--- a/python/filter.py
+++ b/python/filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os

--- a/python/fix_pdf_tex.py
+++ b/python/fix_pdf_tex.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import re
+import sys
+
+re_include_graphics = re.compile(
+        r'\\includegraphics\[width=\\unitlength,page=(\d+)\]')
+re_end_picture = re.compile(r'\\end\{picture\}')
+
+inside = False
+num_pages = int(sys.argv[1])
+for line in sys.stdin:
+    if not inside:
+        m = re_include_graphics.search(line)
+        if m and int(m.group(1)) > num_pages:
+            inside = True
+            sys.stderr.write('skip: %s' % line)
+            continue
+    else:
+        if re_end_picture.search(line):
+            inside = False
+        else:
+            sys.stderr.write('skip: %s' % line)
+            continue
+    print(line)
+

--- a/scala_text.tex
+++ b/scala_text.tex
@@ -39,19 +39,13 @@
 
 \usepackage{luacode}
 
-\begin{luacode*}
-  USE_IPAFONT = os.getenv"USE_IPAFONT"
-  USE_YUFONT = os.getenv"USE_YUFONT"
-  
-  if USE_YUFONT == "true" then
-    tex.sprint("\\AtBeginDocument{\\usepackage[yu-osx, deluxe, expert]{luatexja-preset}}")
-  elseif USE_IPAFONT == "true" then
-    tex.sprint("\\AtBeginDocument{\\usepackage[ipaex, deluxe, expert]{luatexja-preset}}")
-  else
-    tex.sprint("\\AtBeginDocument{\\usepackage[hiragino-pro, deluxe, expert]{luatexja-preset}}")
-  end
-\end{luacode*}
+% 欧文のフォント設定
+\usepackage[default, regular, bold]{sourcesanspro}
+\usepackage[default, regular, bold]{sourceserifpro}
+\setmonofont{CMU Typewriter Text}
 
+% 日本語フォント設定
+\usepackage[haranoaji, deluxe]{luatexja-preset}
 \usepackage[centering]{geometry}
 
 \usepackage[%
@@ -63,7 +57,7 @@
   bookmarksnumbered=true,
   bookmarkstype=toc,
   bookmarksopen=true,
-  pdfauthor={株式会社ドワンゴ},
+  pdfauthor={Japan Scala Association},
   pdftitle={Scala Text}]{hyperref}
 
 \usepackage{xcolor}

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 git submodule update --init
 
@@ -13,7 +13,13 @@ cp -r ./scala_text/src/example_projects ./
 for f in ./img/*.svg
 do
   if [[ $f =~ \./img/(.*)\.svg ]]; then
-    inkscape -z -D --file=`pwd`/img/${BASH_REMATCH[1]}.svg --export-pdf=`pwd`/${BASH_REMATCH[1]}.pdf --export-latex=`pwd`/${BASH_REMATCH[1]}.pdf_tex
+    SVG=`pwd`/img/${BASH_REMATCH[1]}.svg
+    PDF=`pwd`/${BASH_REMATCH[1]}.pdf
+    PDFTEX=`pwd`/${BASH_REMATCH[1]}.pdf_tex
+    inkscape -D "$SVG" --export-filename="$PDF" --export-latex
+    PAGES=$(egrep -a '/Type /Page\b' "$PDF" | wc -l | tr -d ' ')
+    python3 ./python/fix_pdf_tex.py "$PAGES" < "$PDFTEX" > "$PDFTEX.tmp"
+    mv "$PDFTEX.tmp" "$PDFTEX"
   fi
 done
 
@@ -25,7 +31,7 @@ for f in ./scala_text/honkit/*.md
 do
   if [[ $f =~ \./scala_text/honkit/(.*)\.md ]]; then
     cp $f ./target/
-    FILENAME="${BASH_REMATCH[1]}.md" pandoc -o "./target/${BASH_REMATCH[1]}.tex" -f markdown_github+footnotes+header_attributes-hard_line_breaks-intraword_underscores --pdf-engine=lualatex --top-level-division=chapter --listings --filter ./filter.py $f
+    FILENAME="${BASH_REMATCH[1]}.md" pandoc -o "./target/${BASH_REMATCH[1]}.tex" -f markdown_github+footnotes+header_attributes-hard_line_breaks-intraword_underscores --pdf-engine=lualatex --top-level-division=chapter --listings --filter ./python/filter.py $f
   fi
 done
 


### PR DESCRIPTION
- Pandocのバージョンをあげた
- Inkscapeのバージョンがあがり、オプションなどが変更となったためそれに対する変更を加えた
- 日本語フォントをIPAフォントから原ノ味フォントへ変更した
    - あまり使うことがないので環境変数でヒラギノフォントなどに変更できる機能は削除した
- PDFのヘッダー情報の中に`株式会社ドワンゴ`が残っていたため、それを`Japan Scala Association`へ変更した