### PR TITLE
Enable `tty` and use `gfm` instead of `markdown_github`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - .:/workdir
       - ~/.sbt:/root/.sbt
       - ~/.ivy2:/root/.ivy2
+    tty: true

--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,7 @@ for f in ./scala_text/honkit/*.md
 do
   if [[ $f =~ \./scala_text/honkit/(.*)\.md ]]; then
     cp $f ./target/
-    FILENAME="${BASH_REMATCH[1]}.md" pandoc -o "./target/${BASH_REMATCH[1]}.tex" -f markdown_github+footnotes+header_attributes-hard_line_breaks-intraword_underscores --pdf-engine=lualatex --top-level-division=chapter --listings --filter ./python/filter.py $f
+    FILENAME="${BASH_REMATCH[1]}.md" pandoc -o "./target/${BASH_REMATCH[1]}.tex" -f gfm+footnotes+header_attributes-hard_line_breaks-intraword_underscores --pdf-engine=lualatex --top-level-division=chapter --listings --filter ./python/filter.py $f
   fi
 done
 


### PR DESCRIPTION
- inkscapeのエラーを消すため`docker-compose`の設定を変更する
    - > Unable to init server: Could not connect: Connection refused
    - https://github.com/scala-text/scala_text_pdf/runs/7264672552?check_suite_focus=true#step:7:231
- Pandocでは非推奨となった`markdown_github`から`gfm`へ変更する
    - >  [WARNING] Deprecated: markdown_github. Use gfm instead.
    - https://github.com/scala-text/scala_text_pdf/runs/7264672552?check_suite_focus=true#step:7:267