### PR TITLE
Use Alpine Linux as base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,12 @@ jobs:
       continue-on-error: true
 
     - name: Build Docker image
-      run: docker-compose build
+      uses: docker/build-push-action@v3
+      with:
+        file: ./docker/Dockerfile
+        platforms: linux/amd64
+        push: true
+        tags: ghcr.io/scala-text/scala-text-pdf:latest
 
     - name: PDF build
       run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - .:/workdir
       - ~/.sbt:/root/.sbt
       - ~/.ivy2:/root/.ivy2
+    tty: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
-FROM pandoc/core:2.18
+FROM alpine:3.16
 
-MAINTAINER yyu <yyu [at] mental.poker>
+LABEL maintainer="YOSHIMRUA Hikaru <yyu [at] mental.poker>"
 
 ENV TEXLIVE_DEPS \
     xz \
@@ -20,6 +20,12 @@ ENV FONT_DEPS \
     fontconfig-dev
 
 ENV FONT_PATH /usr/share/fonts/
+
+ARG TARGETARCH
+
+ENV PANDOC_VERSION 2.18
+ENV PANDOC_DOWNLOAD_URL https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/pandoc-$PANDOC_VERSION-linux-$TARGETARCH.tar.gz
+ENV PANDOC_ROOT /usr/local/bin/pandoc
 
 ENV PERSISTENT_DEPS \
     openjdk8 \
@@ -52,6 +58,11 @@ RUN mkdir -p $FONT_PATH && \
       rm -rf OTF-source-code-pro-2.038R-ro-1.058R-it.zip source-code-pro && \
     fc-cache -f -v && \
     apk del .font-deps 
+
+# Install Pandoc
+RUN wget -qO- "$PANDOC_DOWNLOAD_URL" | tar -xzf - && \
+    cp pandoc-$PANDOC_VERSION/bin/pandoc $PANDOC_ROOT && \
+    rm -Rf pandoc-$PANDOC_VERSION/
 
 # Install Pandocfilter
 COPY requirements.txt ./


### PR DESCRIPTION
- `pandoc/core:2.18`はベースとなったAlpine Linuxが3.14と古いため、inkscapeが古い状態で提供されてエラーが出ている
- また`pandoc/core`は全体的にARMに対応したイメージを提供していないので、今後M1 MacなどARMベースに対応する際にややこしくなると考えられる
- したがって`pandoc/core`の代わりにAlpine Linuxに切り替えて、Pandocのインストールは手動で行うようにした
- これにともなってDockerイメージビルド方法にも多少の変更が生じた